### PR TITLE
Adding contributor / community documentation

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at (project-team at web-masons dot org)[project-team@web-masons.org]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [project-team at web-masons dot org](mailto:project-team@web-masons.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at (project-team at web-masons dot org)[project-team@web-masons.org]. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing
+So, you want to contribute to the project? Welcome!
+
+## Requirements
+This project uses Ansible and Vagrant to spawn the development environment. You
+will need to have [Vagrant](http://vagrantup.com) and [VirtualBox](http://virtualbox.com)
+installed in order to contribute.
+
+### Vagrant VBGuest Plugin
+We also recommend using the vagrant plugin "vagrant-vbguest" to prevent the
+VirtualBox guest additions from getting out of sync.
+
+````bash
+$ vagrant plugin install vagrant-vbguest
+````
+
+### Vagrant Host Manager Plugin
+We also recommend using the vagrant plugin "vagrant-hostmanager" to manage your
+hosts file if you are dealing with web applications and Vagrant.
+
+```bash
+$ vagrant plugin install vagrant-hostmanager
+```
+
+## The Basics
+This project uses the "GitHub" branching model. If you'd like to read more on
+some of the various branching models, the two big Elephpants in the room are
+the [GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html) and the
+[Gitflow](http://nvie.com/posts/a-successful-git-branching-model/) branching model.
+
+## Running Tests
+The most important part of changes are their tests. Every new feature or issue
+being fixed should have a matching test.
+
+## <a name="bug-reports"></a>Bug Reports
+When the inevitable happens and you discover a bug in the documentation or the
+code, please follow the process below to help us out.
+
+* Search the existing issues to see if the issue has already been filed
+* Make sure the issue is a bug and not simply a preference
+* If you've found a new issue, please then file it
+
+From that point, if you're interest in contributing some code, ask in the issue
+if we're willing to accept a failing test case, and/or a fix. If we are, then
+follow the steps for contributing and we can go from there!
+
+## <a name="feature-requests"></a>Feature Requests
+With most projects, every new feature request should be scrutinized to make sure
+you're not going to experience feature bloat. Every new feature should fit the
+Vision for the project. If you've got an idea for a new feature and you feel it
+fits the vision, file an issue and we can discuss it.
+
+Make sure any feature request you make fits the
+[INVEST](http://en.wikipedia.org/wiki/INVEST_(mnemonic) mnemonic.
+
+## <a name="pull-requests"></a>Pull Requests
+A well written pull request is a huge piece of the success of any open source project.
+Please make sure to take the time to think out the request and document/comment well.
+A good pull request should be the smallest successful feature, akin to the
+[INVEST](http://en.wikipedia.org/wiki/INVEST_(mnemonic) mnemonic used in scrum.
+
+Make sure if you're not a project member and just getting started that you have a
+related issue for your Pull Request and that a project owner approves the work
+before putting the effort in to make the change. Most of the time as long as you're
+following the project vision, we'll welcome additions, but it's better to be save
+than sorry.
+
+Also, make sure your pull request is built with a compilation of great
+[commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+The [Bower](https://github.com/bower/bower/blob/master/CONTRIBUTING.md) project has
+awesome instructions for Pull Requests, I've added a copy here.
+
+Adhering to the following this process is the best way to get your work
+included in the project:
+
+1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
+   and configure the remotes:
+
+   ```bash
+   # Clone your fork of the repo into the current directory
+   git clone https://github.com/<your-username>/<this-project>
+   # Navigate to the newly cloned directory
+   cd <this-project>
+   # Assign the original repo to a remote called "upstream"
+   git remote add upstream https://github.com/<this-org>/<this-project>
+   ```
+
+2. If you cloned a while ago, get the latest changes from upstream:
+
+   ```bash
+   git checkout master
+   git pull upstream master
+   ```
+
+3. Create a new topic branch (off the main project development branch) to
+   contain your feature, change, or fix:
+
+   ```bash
+   git checkout -b <topic-branch-name>
+   ```
+
+4. Make sure to update, or add to the tests when appropriate. Patches and
+   features will not be accepted without tests. Run the tests as relevant to
+   make sure all tests pass after you've made changes.
+
+5. Commit your changes in logical chunks. Please adhere to these [git commit
+   message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+   or your code is unlikely be merged into the main project. Use Git's
+   [interactive rebase](https://help.github.com/articles/interactive-rebase)
+   feature to tidy up your commits before making them public.
+
+6. Locally merge (or rebase) the upstream development branch into your topic branch:
+
+   ```bash
+   git pull [--rebase] upstream master
+   ```
+
+7. Push your topic branch up to your fork:
+
+   ```bash
+   git push origin <topic-branch-name>
+   ```
+
+8. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
+    with a clear title and description.
+
+9. If you are asked to amend your changes before they can be merged in, please
+   use `git commit --amend` (or rebasing for multi-commit Pull Requests) and
+   force push to your remote feature branch. You may also be asked to squash
+   commits.
+
+**IMPORTANT**: By submitting a patch, you agree to license your work under the
+same license as that used by the project.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,82 @@
+## Read First
+Overall, we support three types of issue request. We may add more in the future. We have templates for each issue
+request contained within this template.
+- Bug Report
+- Improvement Request
+- Request for Assistance
+
+Please use the section that makes the most sense, and delete the rest. Each section begins with a Flag and an H1
+level title. Please leave the title so that it's easy for us to categorize it.
+
+
+<!--- ---------------------------------------- BUG REPORT ---------------------------------------- -->
+# Bug Report
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Context
+<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+
+## Possible Fix
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this bug affected you? What were you trying to accomplish? -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop or mobile):
+* Link to your project:
+
+
+<!--- ------------------------------------ IMPROVEMENT REQUEST ----------------------------------- -->
+# Improvement Request
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop or mobile):
+* Link to your project:
+
+
+<!--- --------------------------------------- HELP REQUEST --------------------------------------- -->
+# Request for Assistance
+<!--- Provide a general summary of your request -->
+
+## Context
+<!--- Provide a more detailed introduction to your request for assistance -->
+
+## Your Environment
+<!--- Include as many relevant details about your environment -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop or mobile):
+* Link to your project:
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# STOP!
+Please do not create a Pull Request without creating an issue first. Any change needs to be discussed
+before proceeding. Failure to do so may result in the rejection of the pull request.
+
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+Resolves #XXX
+Resolves #XXX
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pyramid-zappa-api-boilerplate
 A Python boilerplate for creating AWS Lambda API projects using Pyramid and Zappa, orchestrated with Ansible.
 
+Before participating in our communit, please read and agree to our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+
 ## Overview
 We're all working quite a bit with Python and AWS Lambda. In order to create our countless APIs, ETL scripts, Chat Bots,
 etc. we want a boilerplate project that we can share. The hope is that we can share this project amongst ourselves to


### PR DESCRIPTION
## Overview

This PR adds a number of required files to attempt to ensure the proejct is community friendly. Included in this PR are
Pull Request and Issue templates, as well as Contributing Guidelines and a Code of Conduct.

Resolves #3
Resolves #4
Resolves #5
Resolves #6

### Notes

I used a number of reference points for creating these files, included is a list below.
- https://help.github.com/articles/helping-people-contribute-to-your-project/
- https://github.com/blog/2111-issue-and-pull-request-templates
- https://www.talater.com/open-source-templates/#/
- https://www.azavea.com/blog/2017/05/08/github-pull-request-template-workflow/
- https://quickleft.com/blog/pull-request-templates-make-code-review-easier/

## Testing Instructions

 * To test the Pull Request template, open a Pull Request at my
   [Oakensoul fork](https://github.com/oakensoul/pyramid-zappa-api-boilerplate), and see the template in action
 * To test the Code of Conduct, open the README at my
   [Oakensoul fork](https://github.com/oakensoul/pyramid-zappa-api-boilerplate) and click on the Code of Conduct link
 * To test the Contributing Guidelines, open up a new issue at my
   [Oakensoul fork](https://github.com/oakensoul/pyramid-zappa-api-boilerplate) and click on the guidelines link
 * To test the Issue template, open up a new issue at my
   [Oakensoul fork](https://github.com/oakensoul/pyramid-zappa-api-boilerplate) and see the template pre-filled
