### PR TITLE
Adding pip virtualenv

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,32 @@ hosts file if you are dealing with web applications and Vagrant.
 $ vagrant plugin install vagrant-hostmanager
 ```
 
+### NOTE
+If you get the following error the first time you ```vagrant up```...
+```bash
+No guest IP was given to the Vagrant core NFS helper. This is an
+internal error that should be reported as a bug.
+```
+To resolve: ```vagrant halt``` and then ```vagrant up``` again. I'm not sure why it
+works like that, but well, it's a workaround. I think it's only a problem on a new
+machine, but I'm not 100% sure. I've never seen this error before except on my new machine.
+
+## Usage
+* Fork the project
+* Clone your Fork
+* Vagrant Up
+* Activate Python 3.6 (see below)
+
+### Python 3.5
+We're going to attempt to use Python 3.5 for our app. We are using
+virutalenv to manage our Python environment. In order to activate the
+Python3.5 environment, you must execute the following when you enter
+your Vagrant shell.
+
+```bash
+$ source /home/vagrant/python3.5/bin/activate
+```
+
 ## The Basics
 This project uses the "GitHub" branching model. If you'd like to read more on
 some of the various branching models, the two big Elephpants in the room are

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,14 +38,14 @@ machine, but I'm not 100% sure. I've never seen this error before except on my n
 * Vagrant Up
 * Activate Python 3.6 (see below)
 
-### Python 3.5
-We're going to attempt to use Python 3.5 for our app. We are using
+### Python 3.6
+We're going to attempt to use Python 3.6 for our app. We are using
 virutalenv to manage our Python environment. In order to activate the
-Python3.5 environment, you must execute the following when you enter
+Python3.6 environment, you must execute the following when you enter
 your Vagrant shell.
 
 ```bash
-$ source /home/vagrant/python3.5/bin/activate
+$ source /home/vagrant/python3.6/bin/activate
 ```
 
 ## The Basics

--- a/ansible/pip-requirements.txt
+++ b/ansible/pip-requirements.txt
@@ -1,0 +1,5 @@
+boto3
+awscli
+requests
+pytz
+iso8601

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -33,9 +33,3 @@
         requirements: /vagrant/ansible/pip-requirements.txt
         virtualenv: /home/vagrant/python3.6
         virtualenv_python: python3.6
-
-#    - name: Manually create the initial virtualenv
-#      command: virtualenv /home/vagrant/python3.5 -p python3.5 creates="/home/vagrant/python3.5"
-#
-#    - name: Manually install requirements
-#      command: /home/vagrant/python3.5/bin/pip install -r /vagrant/inf/pip/requirements.txt

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -1,18 +1,41 @@
 
 ---
 
-    - name: Update apt cache
-      apt: update-cache=yes cache_valid_time=86400
-      become: yes
-
     - name: Check NTP service to make sure its running
       service: name=ntp state=started enabled=yes
       become: yes
 
-    - name: Install AWS CLI package via Pip
-      pip: name=awscli
+    - name: Add Felix Krull's Python PPA
+      apt_repository:
+        repo: 'ppa:fkrull/deadsnakes'
+        state: present
+
+    - name: Update apt cache
+      apt: update-cache=yes cache_valid_time=86400
+      become: yes
+      become_method: sudo
+
+    - name: Install Python 3.6
+      apt:
+        name: python3.6
+        state: latest
+
+    - name: install python-pip
+      apt: name=python-pip
       become: yes
 
-    - name: Install Boto Python package via Pip
-      pip: name=boto
+    - name: install python-virtualenv
+      apt: name=python-virtualenv
       become: yes
+
+    - name: Install PIP requirements
+      pip:
+        requirements: /vagrant/ansible/pip-requirements.txt
+        virtualenv: /home/vagrant/python3.6
+        virtualenv_python: python3.6
+
+#    - name: Manually create the initial virtualenv
+#      command: virtualenv /home/vagrant/python3.5 -p python3.5 creates="/home/vagrant/python3.5"
+#
+#    - name: Manually install requirements
+#      command: /home/vagrant/python3.5/bin/pip install -r /vagrant/inf/pip/requirements.txt

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -69,10 +69,10 @@ apt-get -y autoremove
 
 cd ansible
 
-echo "  Application Bootstrap 1/2. Install Ansible Galaxy role requirements from requirements.yml"
-if [ -s requirements.yml ]
+echo "  Application Bootstrap 1/2. Install Ansible Galaxy role requirements from galaxy-requirements.yml"
+if [ -s galaxy-requirements.yml ]
 then
-    ansible-galaxy install -r requirements.yml --force
+    ansible-galaxy install -r galaxy-requirements.yml --force
 fi
 
 echo "  Application Bootstrap 2/2. Ansible (allthethings)..."

--- a/script/console
+++ b/script/console
@@ -23,6 +23,20 @@ if [ -n "$1" ]; then
 else
   # no argument provided, so just run the local console in the development
   # environment. Ensure the application is up to date first.
-  script/update.sh
-    echo "local console not yet implemented"
+  # script/update.sh
+
+  echo "To run a local console, please execute the following command:"
+  echo "    source ~/python3.6/bin/activate"
 fi
+
+
+
+
+
+
+
+
+
+
+
+Can I just Python-ify this script to do what I want instead of a Shell Script????


### PR DESCRIPTION
## Overview

I'm updating our Ansible provisioner playbook to use VirtualEnv and install Python 3.6 to it. I also configured the playbook to use a pip-requirements file so that we can manage all of our Python 3.6 modules required in a single file instead of having to update the playbook itself. Instructions for how to activate Python 3.6 are in the contributing documentation.

Resolves #11 

## Notes
I tried to figure out how to update ```script/console``` to be able to execute the activate command instead, but I couldn't figure it out. I think it ends up creating a headless environment when you do that, which isn't really very useful.

## Testing Instructions

 * Spin up your vagrant box via ```vagrant up```
 * SSH into the box via ```vagrant ssh```
 * Switch to Python 3.6 VirtualEnv via ```source /home/vagrant/python3.6/bin/activate```
 * Note that your Path properly lets you know you're in (python3.6)
 * Type ```python --version``` and note that you should get a response of "Python 3.6.1"